### PR TITLE
[1.x] Enhancement: Account for linked fields in JIT scanner

### DIFF
--- a/src/JitSafeScanner.php
+++ b/src/JitSafeScanner.php
@@ -116,8 +116,8 @@ class JitSafeScanner
                     }
 
                     continue;
-                } elseif (is_string($field['imports'] ?? null)) {
-                    if ($imports = FieldsetFacade::find($field['imports'])) {
+                } elseif (is_string($field['import'] ?? null)) {
+                    if ($imports = FieldsetFacade::find($field['import'])) {
                         call_user_func_array('array_push', array_merge([&$stack], $imports->contents()['fields']));
                     }
 

--- a/src/JitSafeScanner.php
+++ b/src/JitSafeScanner.php
@@ -84,6 +84,12 @@ class JitSafeScanner
             if (($value['type'] ?? null) === 'miniset_classes' && is_array($value['fields'] ?? null)) {
                 $configs[] = $value;
             }
+            if (is_string($value['field'] ?? null) && str($value['field'])->contains('.')) {
+                $referencedField = FieldFacade::find($value['field']);
+                if(($referencedField->config()['type'] ?? null) === 'miniset_classes'){
+                    $configs[] = array_merge($value['config'], $referencedField->config());
+                }
+            }
         }
 
         return $configs;


### PR DESCRIPTION
Currently, if you have a linked `miniset_classes` field (a specific __field__, not the entire field**set**) within a blueprint, it doesn't get picked up by the JIT scanner, since the `type` isn't available on the `$blueprint->contents()`. This PR adds an additional check within the `findConfigs` method, that examines the underlying/linked field-type. If it's a `miniset_classes`, then the two configs are merged and added to the found `$configs`.

The primary use-case for this IMHO, is to have a consistent and reusable set of variants and their labels, which can then be used across many blueprints as a linked field, making management/changes much easier. For example, the following works fine/as-expected, from within the CP. But the JIT scanner (in its current form) doesn't pick up the linked field.

### A `tailwind_minisets` fieldset, with a `miniset_screen_sizes` field:

```yaml
handle: miniset_screen_sizes
    field:
      type: miniset_classes
      display: 'Miniset: Screen Sizes'
      variants:
        sm: 'Small (Phones)'
        md: 'Medium (Tablets)'
        lg: 'Large (Laptops)'
        xl: 'X-Large (Monitors)'
```

### And then to use that ☝ in a blueprint, just add fields for classes without overriding variants:

```yaml
handle: layout
field: tailwind_minisets.miniset_screen_sizes
config:
  display: Layout
  fields:
    -
      handle: border_width
      field:
        display: 'Border Width'
        type: select
        options:
          border-0: None
          border: X-Thin
          border-2: Thin
          border-4: Medium
          border-8: Thick
          'border-[12px]': X-Thick
          'rounded-[16px]': 2X-Thick
```

Let me know if there's anything I can do to clarify intent/purpose, or if there are edits you'd like to see made!