### PR TITLE
[1.x] Fix type error when variants config is null

### DIFF
--- a/src/Fieldtypes/MinisetClassesFieldtype.php
+++ b/src/Fieldtypes/MinisetClassesFieldtype.php
@@ -135,7 +135,7 @@ class MinisetClassesFieldtype extends Fieldtype
             'existing' => collect($this->field->value())->mapWithKeys(function ($group) {
                 return [$group['_id'] => $this->fields()->addValues($group)->meta()];
             })->toArray(),
-            'variant_indexes' => array_flip(array_keys($this->config('variants'))),
+            'variant_indexes' => array_flip(array_keys($this->config('variants') ?? [])),
         ];
     }
 


### PR DESCRIPTION
Small issue with changes made in #5. The `array_keys` used when preloading a `MinisetClassesFieldtype` assumes that the variants config option will be set and have values, but that can technically be null. Throws a type error:

`array_keys(): Argument #1 ($array) must be of type array, null given`

This PR just ensures that we're providing an array to start with.